### PR TITLE
fix: Downgrade Snowflake provider version constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,14 +120,14 @@ module "snowflake_shared_database" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_snowflake"></a> [snowflake](#provider\_snowflake) | >= 0.95 |
+| <a name="provider_snowflake"></a> [snowflake](#provider\_snowflake) | >= 0.94.0 |
 
 ## Requirements
 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_snowflake"></a> [snowflake](#requirement\_snowflake) | >= 0.95 |
+| <a name="requirement_snowflake"></a> [snowflake](#requirement\_snowflake) | >= 0.94.0 |
 
 ## Resources
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -112,14 +112,14 @@ var.from_share
 
 | Name | Version |
 |------|---------|
-| <a name="provider_snowflake"></a> [snowflake](#provider\_snowflake) | >= 0.95 |
+| <a name="provider_snowflake"></a> [snowflake](#provider\_snowflake) | >= 0.94.0 |
 
 ## Requirements
 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_snowflake"></a> [snowflake](#requirement\_snowflake) | >= 0.95 |
+| <a name="requirement_snowflake"></a> [snowflake](#requirement\_snowflake) | >= 0.94.0 |
 
 ## Resources
 

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     snowflake = {
       source  = "Snowflake-Labs/snowflake"
-      version = ">= 0.95"
+      version = ">= 0.94.0"
     }
   }
 }

--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -72,7 +72,7 @@ No providers.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_snowflake"></a> [snowflake](#requirement\_snowflake) | >= 0.95 |
+| <a name="requirement_snowflake"></a> [snowflake](#requirement\_snowflake) | >= 0.94.0 |
 
 ## Resources
 

--- a/examples/simple/versions.tf
+++ b/examples/simple/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     snowflake = {
       source  = "Snowflake-Labs/snowflake"
-      version = ">= 0.95"
+      version = ">= 0.94.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     snowflake = {
       source  = "Snowflake-Labs/snowflake"
-      version = ">= 0.95"
+      version = ">= 0.94.0"
     }
   }
 }


### PR DESCRIPTION
Snowflake provider version constraint can be downgraded, since resource is available from `0.93.0`.
Setting `0.94.0` to unify with other modules that were reworked recently.