### PR TITLE
fix: Remove output due to provider versions issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,6 @@ module "snowflake_shared_database" {
 | <a name="output_enable_console_output"></a> [enable\_console\_output](#output\_enable\_console\_output) | If true, enables stdout/stderr fast path logging for anonymous stored procedures |
 | <a name="output_external_volume"></a> [external\_volume](#output\_external\_volume) | The database parameter that specifies the default external volume to use for Iceberg tables |
 | <a name="output_from_share"></a> [from\_share](#output\_from\_share) | The name of the share from which the database is created |
-| <a name="output_fully_qualified_name"></a> [fully\_qualified\_name](#output\_fully\_qualified\_name) | The fully qualified name of the database |
 | <a name="output_log_level"></a> [log\_level](#output\_log\_level) | Specifies the severity level of messages that should be ingested and made available in the active event table. Valid options are: [TRACE DEBUG INFO WARN ERROR FATAL OFF] |
 | <a name="output_name"></a> [name](#output\_name) | Name of the database |
 | <a name="output_quoted_identifiers_ignore_case"></a> [quoted\_identifiers\_ignore\_case](#output\_quoted\_identifiers\_ignore\_case) | If true, the case of quoted identifiers is ignored |

--- a/outputs.tf
+++ b/outputs.tf
@@ -78,11 +78,6 @@ output "enable_console_output" {
   value       = one(snowflake_shared_database.this[*].enable_console_output)
 }
 
-output "fully_qualified_name" {
-  description = "The fully qualified name of the database"
-  value       = one(snowflake_shared_database.this[*].fully_qualified_name)
-}
-
 output "roles" {
   description = "Snowflake Roles"
   value       = local.roles


### PR DESCRIPTION
Rollback / remove `fully_qualified_name` output to continue support for `0.94.1` Snowflake terraform provider version (output became available in `0.95.0`)